### PR TITLE
Remove irb warning in rails c

### DIFF
--- a/Gemfile.core
+++ b/Gemfile.core
@@ -34,7 +34,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.8.2'
-  gem 'rspec_junit_formatter'
+  gem 'rspec_junit_formatter', require: false
   gem 'factory_bot_rails'
   gem 'webmock'
 


### PR DESCRIPTION
It's due to [rspec-rails issue](https://github.com/rspec/rspec-rails/issues/1645)